### PR TITLE
Fix cross-platform compatibility for Windows and Linux

### DIFF
--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -5,8 +5,9 @@ import { spawn } from 'node:child_process';
 import { setTimeout as wait } from 'node:timers/promises';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 
-const root = new URL('..', import.meta.url).pathname; // codex-webui/
+const root = fileURLToPath(new URL('..', import.meta.url)); // codex-webui/
 
 function startServer(port = 5065) {
   const env = { ...process.env, PORT: String(port) };
@@ -32,7 +33,7 @@ async function waitForHealth(url, tries = 40) {
 
 test('server starts and /health responds', async (t) => {
   const { child, url } = startServer(5065);
-  t.after(() => { try { child.kill('SIGKILL'); } catch {} });
+  t.after(() => { try { child.kill(); } catch {} });
   assert.equal(await waitForHealth(url), true, 'health should respond');
   const r = await fetch(url + '/health');
   assert.equal(r.status, 200);
@@ -42,7 +43,7 @@ test('server starts and /health responds', async (t) => {
 
 test('GET /config returns defaults', async (t) => {
   const { child, url } = startServer(5066);
-  t.after(() => { try { child.kill('SIGKILL'); } catch {} });
+  t.after(() => { try { child.kill(); } catch {} });
   assert.equal(await waitForHealth(url), true);
   const r = await fetch(url + '/config');
   assert.equal(r.status, 200);
@@ -53,7 +54,7 @@ test('GET /config returns defaults', async (t) => {
 
 test('PUT /config roundtrip', async (t) => {
   const { child, url } = startServer(5067);
-  t.after(() => { try { child.kill('SIGKILL'); } catch {} });
+  t.after(() => { try { child.kill(); } catch {} });
   assert.equal(await waitForHealth(url), true);
   const payload = { model: 'gpt-5', approval_policy: 'never' };
   const put = await fetch(url + '/config', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
@@ -66,7 +67,7 @@ test('PUT /config roundtrip', async (t) => {
 
 test('GET /sessions returns JSON structure', async (t) => {
   const { child, url } = startServer(5068);
-  t.after(() => { try { child.kill('SIGKILL'); } catch {} });
+  t.after(() => { try { child.kill(); } catch {} });
   assert.equal(await waitForHealth(url), true);
   const r = await fetch(url + '/sessions');
   assert.equal(r.status, 200);


### PR DESCRIPTION
### **User description**
This commit addresses 6 critical cross-platform compatibility issues:

1. Path concatenation: Replace string concatenation with path.join() in serveStatic() to properly handle Windows backslashes (server.js:516)

2. URL to filesystem path conversion: Use fileURLToPath() instead of .pathname to fix Windows path handling in tests (basic.test.js:9)

3. Process termination: Remove SIGKILL (Unix-specific) in favor of default kill() that works on both platforms (server.js:350, tests)

4. Line ending handling: Standardize all .split('\n') to .split(/\r?\n/) to handle both Unix (LF) and Windows (CRLF) line endings properly (server.js:78,88,285,392,585)

All changes maintain backward compatibility while ensuring the WebUI runs correctly on both Windows and Linux systems.

Tests: All 4 tests passing


___

### **PR Type**
Bug fix


___

### **Description**
- Replace string concatenation with `path.join()` for cross-platform path handling

- Standardize line ending handling with regex `/\r?\n/` for Windows and Unix

- Use `fileURLToPath()` instead of `.pathname` for proper URL-to-path conversion

- Remove Unix-specific `SIGKILL` signal, use default `kill()` for cross-platform compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Path Issues<br/>String concat + pathname"] -->|"path.join() +<br/>fileURLToPath()"| B["Cross-platform<br/>Path Handling"]
  C["Line Ending Issues<br/>split\n only"] -->|"split(/\r?\n/)"| B
  D["Process Termination<br/>SIGKILL Unix-only"] -->|"kill() default"| B
  B -->|"Result"| E["Windows & Linux<br/>Compatible"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Cross-platform path and line ending fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server.js

<ul><li>Replace 5 instances of <code>.split('\n')</code> with <code>.split(/\r?\n/)</code> to handle <br>both Unix LF and Windows CRLF line endings<br> <li> Change path concatenation in <code>serveStatic()</code> from string concatenation <br>to <code>path.join()</code> for proper Windows backslash handling<br> <li> Remove <code>SIGKILL</code> signal from <code>proc.kill('SIGKILL')</code> to use default <br>cross-platform kill behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/harryneopotter/Codex-webui/pull/3/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>basic.test.js</strong><dd><code>Fix test path resolution and process termination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/basic.test.js

<ul><li>Import <code>fileURLToPath</code> from <code>node:url</code> module<br> <li> Replace <code>.pathname</code> with <code>fileURLToPath()</code> for proper Windows path <br>conversion in root directory resolution<br> <li> Remove <code>SIGKILL</code> signal from all 5 test cleanup calls, using default <br><code>kill()</code> instead</ul>


</details>


  </td>
  <td><a href="https://github.com/harryneopotter/Codex-webui/pull/3/files#diff-0ec992da7b8b9550950f6cc32a40a77ffd77d99aaff6caedc4ca191f6e9ab5ef">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in data parsing and line boundary handling across multiple processing paths
  * Updated file path handling mechanisms
  * Modified process termination logic

* **Tests**
  * Updated test infrastructure and dependencies for improved test execution

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->